### PR TITLE
DRYs up error snackbar and implements it consistently across components

### DIFF
--- a/src/components/ErrorSnackbar.js
+++ b/src/components/ErrorSnackbar.js
@@ -1,0 +1,35 @@
+import { Snackbar } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+
+const ErrorSnackbar = ({ error }) => {
+  const [alertOpen, setAlertOpen] = useState(Boolean(error));
+
+  useEffect(() => {
+    if (error) {
+      setAlertOpen(true);
+    }
+  }, [error]);
+
+  return error ? (
+    <Snackbar open={alertOpen} autoHideDuration={6000} onClose={() => setAlertOpen(false)}>
+      <Alert severity="error">
+        Error:
+        {error.message}
+      </Alert>
+    </Snackbar>
+  ) : null;
+};
+
+ErrorSnackbar.propTypes = {
+  error: PropTypes.shape({
+    message: PropTypes.node,
+  }),
+};
+
+ErrorSnackbar.defaultProps = {
+  error: null,
+};
+
+export default ErrorSnackbar;

--- a/src/components/FeaturedCommunities.js
+++ b/src/components/FeaturedCommunities.js
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import { CircularProgress } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import FeaturedPost from './FeaturedPost';
+import React, { useEffect, useState } from 'react';
 import endpoints from '../constants/endpoints';
 import routes from '../constants/routes';
 import { trackException } from '../services/telemetry.service';
+import ErrorSnackbar from './ErrorSnackbar';
+import FeaturedPost from './FeaturedPost';
 
 export default function FeaturedCommunities() {
   const [error, setError] = useState(null);
@@ -42,14 +42,8 @@ export default function FeaturedCommunities() {
         Featured Communities
       </Typography>
 
-      {error && (
-        <Snackbar open autoHideDuration={6000}>
-          <Alert severity="error">
-            Error:
-            {error.message}
-          </Alert>
-        </Snackbar>
-      )}
+      <ErrorSnackbar error={error} />
+
       <Grid container spacing={4}>
         {!isLoaded ? (
           <Grid item xs={12} md={12}>

--- a/src/components/FeaturedConferences.js
+++ b/src/components/FeaturedConferences.js
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import { CircularProgress } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import FeaturedPost from './FeaturedPost';
+import React, { useEffect, useState } from 'react';
 import endpoints from '../constants/endpoints';
 import routes from '../constants/routes';
 import { trackException } from '../services/telemetry.service';
+import ErrorSnackbar from './ErrorSnackbar';
+import FeaturedPost from './FeaturedPost';
 
 export default function FeaturedConferences() {
   const [error, setError] = useState(null);
@@ -42,14 +42,8 @@ export default function FeaturedConferences() {
         Featured Conferences
       </Typography>
 
-      {error && (
-        <Snackbar open autoHideDuration={6000}>
-          <Alert severity="error">
-            Error:
-            {error.message}
-          </Alert>
-        </Snackbar>
-      )}
+      <ErrorSnackbar error={error} />
+
       <Grid container spacing={4}>
         {!isLoaded ? (
           <Grid item xs={12} md={12}>

--- a/src/components/FeaturedSpeakers.js
+++ b/src/components/FeaturedSpeakers.js
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import { CircularProgress } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import FeaturedPost from './FeaturedPost';
+import React, { useEffect, useState } from 'react';
 import endpoints from '../constants/endpoints';
 import routes from '../constants/routes';
 import { trackException } from '../services/telemetry.service';
+import ErrorSnackbar from './ErrorSnackbar';
+import FeaturedPost from './FeaturedPost';
 
 export default function FeaturedSpeakers() {
   const [error, setError] = useState(null);
@@ -42,14 +42,8 @@ export default function FeaturedSpeakers() {
         Featured Speakers
       </Typography>
 
-      {error && (
-        <Snackbar open autoHideDuration={6000}>
-          <Alert severity="error">
-            Error:
-            {error.message}
-          </Alert>
-        </Snackbar>
-      )}
+      <ErrorSnackbar error={error} />
+
       <Grid container spacing={4}>
         {!isLoaded ? (
           <Grid item xs={12} md={12}>

--- a/src/pages/Communities.js
+++ b/src/pages/Communities.js
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import { CircularProgress } from '@material-ui/core';
 import Container from '@material-ui/core/Container';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import ResultList from '../components/ResultList';
-import routes from '../constants/routes';
-import endpoints from '../constants/endpoints';
-import { trackException } from '../services/telemetry.service';
+import React, { useEffect, useState } from 'react';
+import ErrorSnackbar from '../components/ErrorSnackbar';
 import FindA from '../components/FindA';
+import ResultList from '../components/ResultList';
+import endpoints from '../constants/endpoints';
+import routes from '../constants/routes';
+import { trackException } from '../services/telemetry.service';
 
 export default function Communities() {
   const [error, setError] = useState(null);
@@ -36,16 +36,6 @@ export default function Communities() {
     fetchData();
   }, []);
 
-  if (error) {
-    return (
-      <Snackbar open autoHideDuration={6000}>
-        <Alert severity="error">
-          Error:
-          {error.message}
-        </Alert>
-      </Snackbar>
-    );
-  }
   return (
     <>
       <FindA text="Community" />
@@ -53,6 +43,8 @@ export default function Communities() {
       <Container maxWidth="lg" style={{ padding: 24, minHeight: '100vh' }}>
         {!isLoaded ? <CircularProgress /> : <ResultList data={communities} />}
       </Container>
+
+      <ErrorSnackbar error={error} />
     </>
   );
 }

--- a/src/pages/CommunityDetail.js
+++ b/src/pages/CommunityDetail.js
@@ -1,17 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import { CircularProgress } from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
-import Chip from '@material-ui/core/Chip';
-import Disqus from 'disqus-react';
 import Typography from '@material-ui/core/Typography';
+import Disqus from 'disqus-react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import FeaturedPost from '../components/FeaturedPost';
 import BreadCrumbs from '../components/BreadCrumbs';
-import FindA from '../components/FindA';
 import DetailTabs from '../components/DetailTabs';
+import ErrorSnackbar from '../components/ErrorSnackbar';
 import FeaturedCommunities from '../components/FeaturedCommunities';
+import FeaturedPost from '../components/FeaturedPost';
+import FindA from '../components/FindA';
 import config from '../constants/config';
 import endpoints from '../constants/endpoints';
 import routes from '../constants/routes';
@@ -60,16 +60,6 @@ export default function CommunityDetail() {
     fetchData();
   }, [slug]);
 
-  if (error) {
-    return (
-      <Snackbar open autoHideDuration={6000}>
-        <Alert severity="error">
-          Error:
-          {error.message}
-        </Alert>
-      </Snackbar>
-    );
-  }
   return (
     <>
       <FindA text="Community" />
@@ -111,6 +101,8 @@ export default function CommunityDetail() {
           </>
         )}
       </Container>
+
+      <ErrorSnackbar error={error} />
     </>
   );
 }

--- a/src/pages/ConferenceDetail.js
+++ b/src/pages/ConferenceDetail.js
@@ -1,17 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import { CircularProgress } from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
-import Chip from '@material-ui/core/Chip';
-import Disqus from 'disqus-react';
 import Typography from '@material-ui/core/Typography';
+import Disqus from 'disqus-react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import FeaturedPost from '../components/FeaturedPost';
 import BreadCrumbs from '../components/BreadCrumbs';
-import FindA from '../components/FindA';
 import DetailTabs from '../components/DetailTabs';
+import ErrorSnackbar from '../components/ErrorSnackbar';
 import FeaturedConferences from '../components/FeaturedConferences';
+import FeaturedPost from '../components/FeaturedPost';
+import FindA from '../components/FindA';
 import config from '../constants/config';
 import endpoints from '../constants/endpoints';
 import routes from '../constants/routes';
@@ -60,16 +60,6 @@ export default function ConferenceDetail() {
     fetchData();
   }, [slug]);
 
-  if (error) {
-    return (
-      <Snackbar open autoHideDuration={6000}>
-        <Alert severity="error">
-          Error:
-          {error.message}
-        </Alert>
-      </Snackbar>
-    );
-  }
   return (
     <>
       <FindA text="Conference" />
@@ -111,6 +101,8 @@ export default function ConferenceDetail() {
           </>
         )}
       </Container>
+
+      <ErrorSnackbar error={error} />
     </>
   );
 }

--- a/src/pages/Conferences.js
+++ b/src/pages/Conferences.js
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import { CircularProgress } from '@material-ui/core';
 import Container from '@material-ui/core/Container';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import ResultList from '../components/ResultList';
-import routes from '../constants/routes';
-import endpoints from '../constants/endpoints';
+import React, { useEffect, useState } from 'react';
+import ErrorSnackbar from '../components/ErrorSnackbar';
 import FindA from '../components/FindA';
+import ResultList from '../components/ResultList';
+import endpoints from '../constants/endpoints';
+import routes from '../constants/routes';
 import { trackException } from '../services/telemetry.service';
 
 export default function Conferences() {
@@ -36,16 +36,6 @@ export default function Conferences() {
     fetchData();
   }, []);
 
-  if (error) {
-    return (
-      <Snackbar open autoHideDuration={6000}>
-        <Alert severity="error">
-          Error:
-          {error.message}
-        </Alert>
-      </Snackbar>
-    );
-  }
   return (
     <>
       <FindA text="Conference" />
@@ -53,6 +43,8 @@ export default function Conferences() {
       <Container maxWidth="lg" style={{ padding: 24, minHeight: '100vh' }}>
         {!isLoaded ? <CircularProgress /> : <ResultList data={conferences} />}
       </Container>
+
+      <ErrorSnackbar error={error} />
     </>
   );
 }

--- a/src/pages/Search.js
+++ b/src/pages/Search.js
@@ -1,12 +1,12 @@
+import { CircularProgress } from '@material-ui/core';
+import Container from '@material-ui/core/Container';
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import Container from '@material-ui/core/Container';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import ResultList from '../components/ResultList';
-import routes from '../constants/routes';
-import endpoints from '../constants/endpoints';
+import ErrorSnackbar from '../components/ErrorSnackbar';
 import FindA from '../components/FindA';
+import ResultList from '../components/ResultList';
+import endpoints from '../constants/endpoints';
+import routes from '../constants/routes';
 import { trackException } from '../services/telemetry.service';
 
 function useQuery() {
@@ -51,16 +51,6 @@ export default function Search() {
     fetchData();
   }, [terms]);
 
-  if (error) {
-    return (
-      <Snackbar open autoHideDuration={6000}>
-        <Alert severity="error">
-          Error:
-          {error.message}
-        </Alert>
-      </Snackbar>
-    );
-  }
   return (
     <>
       <FindA text="Speaker, Conference, or Community" />
@@ -68,6 +58,8 @@ export default function Search() {
       <Container maxWidth="lg" style={{ padding: 24, minHeight: '100vh' }}>
         {!isLoaded ? <CircularProgress /> : <ResultList data={results} orderBy="score" />}
       </Container>
+
+      <ErrorSnackbar error={error} />
     </>
   );
 }

--- a/src/pages/SpeakerDetail.js
+++ b/src/pages/SpeakerDetail.js
@@ -1,17 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import { CircularProgress } from '@material-ui/core';
+import Chip from '@material-ui/core/Chip';
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
-import Chip from '@material-ui/core/Chip';
-import Disqus from 'disqus-react';
 import Typography from '@material-ui/core/Typography';
+import Disqus from 'disqus-react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import FeaturedPost from '../components/FeaturedPost';
 import BreadCrumbs from '../components/BreadCrumbs';
-import FindA from '../components/FindA';
 import DetailTabs from '../components/DetailTabs';
+import ErrorSnackbar from '../components/ErrorSnackbar';
+import FeaturedPost from '../components/FeaturedPost';
 import FeaturedSpeakers from '../components/FeaturedSpeakers';
+import FindA from '../components/FindA';
 import config from '../constants/config';
 import endpoints from '../constants/endpoints';
 import routes from '../constants/routes';
@@ -60,16 +60,6 @@ export default function SpeakerDetail() {
     fetchData();
   }, [slug]);
 
-  if (error) {
-    return (
-      <Snackbar open autoHideDuration={6000}>
-        <Alert severity="error">
-          Error:
-          {error.message}
-        </Alert>
-      </Snackbar>
-    );
-  }
   return (
     <>
       <FindA text="Speaker" />
@@ -111,6 +101,8 @@ export default function SpeakerDetail() {
           </>
         )}
       </Container>
+
+      <ErrorSnackbar error={error} />
     </>
   );
 }

--- a/src/pages/Speakers.js
+++ b/src/pages/Speakers.js
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import { CircularProgress } from '@material-ui/core';
 import Container from '@material-ui/core/Container';
-import { CircularProgress, Snackbar } from '@material-ui/core';
-import { Alert } from '@material-ui/lab';
-import ResultList from '../components/ResultList';
-import routes from '../constants/routes';
-import endpoints from '../constants/endpoints';
+import React, { useEffect, useState } from 'react';
+import ErrorSnackbar from '../components/ErrorSnackbar';
 import FindA from '../components/FindA';
+import ResultList from '../components/ResultList';
+import endpoints from '../constants/endpoints';
+import routes from '../constants/routes';
 import { trackException } from '../services/telemetry.service';
 
 export default function Speakers() {
@@ -36,23 +36,13 @@ export default function Speakers() {
     fetchData();
   }, []);
 
-  if (error) {
-    return (
-      <Snackbar open autoHideDuration={6000}>
-        <Alert severity="error">
-          Error:
-          {error.message}
-        </Alert>
-      </Snackbar>
-    );
-  }
   return (
     <>
       <FindA text="Speaker" />
-
       <Container maxWidth="lg" style={{ padding: 24, minHeight: '100vh' }}>
         {!isLoaded ? <CircularProgress /> : <ResultList data={speakers} />}
       </Container>
+      <ErrorSnackbar error={error} />
     </>
   );
 }


### PR DESCRIPTION
I just noticed this template code in a lot of places, so I made a component to consolidate it. Also, some components were returning just the snackbar on error which I can't imagine was the intent, so you'll see that I changed Communities, CommunityDetail, ConferenceDetail, Conferences,  Search, SpeakerDetail, and Speakers to render the snackbar _in addition_ to the rest of the markup when there's an error instead of either/or.